### PR TITLE
Override padding style from VS Code atlasmap/atlasmap#749

### DIFF
--- a/src/atlasMapWebView.ts
+++ b/src/atlasMapWebView.ts
@@ -86,8 +86,9 @@ export default class AtlasMapPanel {
 		fetchUrl(url, function(error, meta, body) {
 			try {
 				var content =  body.toString();
-				content = body.toString().replace('href="/"', 'href="'+url+'/"');
-				AtlasMapPanel.currentPanel._panel.webview.html = content;
+				var contentWithHrefFullySpecified = content.replace('href="/"', 'href="'+url+'/"');
+				var contentWithHrefFullySpecifiedAndCSS = contentWithHrefFullySpecified.replace('<body>', '<body style="padding: 0">');
+				AtlasMapPanel.currentPanel._panel.webview.html = contentWithHrefFullySpecifiedAndCSS;
 			} catch (err) {
 				console.log(err.toString());
 			}

--- a/src/test/command.test.ts
+++ b/src/test/command.test.ts
@@ -76,7 +76,7 @@ describe("AtlasMap/Commands", function() {
 			let url:string = "http://localhost:" + port;
 			const body = await getWebUI(url);
 			expect(body, "Unexpected html response body").to.contain("AtlasMap");
-			expect(atlasMapWebView.default.currentPanel._panel.webview.html).to.contain(url);
+			expect(atlasMapWebView.default.currentPanel._panel.webview.html).to.contain(url).and.to.contain('<body style="padding: 0">');
 		});
 	});
 


### PR DESCRIPTION
VS Code is setting some specific styles by default. need to set back to
default values to take all the place and don't have cropped nav bar

Signed-off-by: Aurélien Pupier <apupier@redhat.com>